### PR TITLE
Add lego image for generating lets encrypt certs

### DIFF
--- a/lego/Dockerfile
+++ b/lego/Dockerfile
@@ -1,0 +1,9 @@
+FROM xenolf/lego:latest
+
+RUN apk add --no-cache \
+        bash           \
+        gnupg
+
+ENTRYPOINT []
+
+CMD /bin/bash


### PR DESCRIPTION
Add a docker image for use in letsencrypt cert renewal pipelines.