### PR TITLE
Add a basic make container

### DIFF
--- a/make/Dockerfile
+++ b/make/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+        bash           \
+        make           \
+        tar            \
+        gzip           \
+        zip            \
+        && rm -rf /var/cache/apk/*
+
+CMD /bin/bash


### PR DESCRIPTION
This container is used for packaging our lambda functions and therefore
only needs make and zip.  The addition of tar and gzip are just to make
the container a little more useful if needed elsewhere.