### PR TITLE
Upgrade packer to 1.3.5

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -2,5 +2,5 @@ FROM williamyeh/ansible:alpine3
 
 RUN apk add --update bash curl gnupg gzip make git && rm -rf /var/cache/apk/*
 
-RUN curl https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip | \
+RUN curl https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip | \
     zcat > /usr/local/bin/packer && chmod +x /usr/local/bin/packer


### PR DESCRIPTION
Upgrade packer to 1.3.5 for the improved retry logic implemented in 1.2.5+.

This should resolve the `Error waiting for AMI Copy: RequestLimitExceeded: Request limit exceeded.` error we are getting.