### PR TITLE
Fix go-node image missing npm and bump go-node go version

### DIFF
--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -4,7 +4,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install nodejs && \
+    apt-get -y install nodejs npm && \
     apt-get clean
 
 CMD /bin/bash

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.12.12
+FROM golang:1.13.8
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install nodejs npm && \
+    apt-get -y install nodejs=8.* && \
     apt-get clean
 
 CMD /bin/bash


### PR DESCRIPTION
* Fix issue with missing npm for `go-node` image
* Bump `go-node` go version to latest