### PR TITLE
Upgrade fly to 6.7.1

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 RUN gem install json --no-document
 
 RUN cd /usr/local/bin \
-    && curl -L https://github.com/concourse/concourse/releases/download/v5.7.2/fly-5.7.2-linux-amd64.tgz | tar -xvz \
+    && curl -L https://github.com/concourse/concourse/releases/download/v6.7.1/fly-6.7.1-linux-amd64.tgz | tar -xvz \
     && chmod +x /usr/local/bin/fly
 
 CMD /bin/bash


### PR DESCRIPTION
Upgrade `fly` binary to latest version (6.7.1) to keep in sync with our
upgraded concourse.