### PR TITLE
Use golang as base image for nancy

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,11 +1,4 @@
-FROM alpine:latest
-
-RUN apk update \
-    && apk add --no-cache --update \
-       ca-certificates \
-       bash \
-       make \
-    && rm -rf /var/cache/apk/*
+FROM golang:1.15
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.8/nancy-v1.0.8-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy


### PR DESCRIPTION
### What

To use the new form of invoking nancy (`go list -m all | nancy sleuth`) requires go to be installed instead of just nancy as before. This new version of the container is based off `golang` instead of `alpine`. As a result it also no longer needs the certs manually installed as this has been done by the golang image already.

### How to review

- `cd nancy`
- Rebuild the image with `docker build -t dp-concourse-tools-nancy:latest .`
- Check the `go` command runs with `docker run --rm dp-concourse-tools-nancy:latest nancy --version`
- Check the `nancy` command runs `docker run --rm dp-concourse-tools-nancy:latest go version`

### Who can review

Anyone but me