### PR TITLE
Upgrade fly to latest (6.7.3)

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 RUN gem install json --no-document
 
 RUN cd /usr/local/bin \
-    && curl -L https://github.com/concourse/concourse/releases/download/v6.7.1/fly-6.7.1-linux-amd64.tgz | tar -xvz \
+    && curl -L https://github.com/concourse/concourse/releases/download/v6.7.3/fly-6.7.3-linux-amd64.tgz | tar -xvz \
     && chmod +x /usr/local/bin/fly
 
 CMD /bin/bash


### PR DESCRIPTION
Upgrade `fly` docker image to latest version to be inline with the concourse server.