### PR TITLE
Update nancy to latest version for both node-go and nancy packages

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.8/nancy-v1.0.8-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.11/nancy-v1.0.11-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 CMD /bin/bash

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,6 +1,7 @@
-FROM golang:1.13.8
+FROM golang:1.15.7
 
-RUN curl -o $GOPATH/bin/nancy -sL https://github.com/sonatype-nexus-community/nancy/releases/download/v0.2.0/nancy-linux.amd64-v0.2.0 && chmod 755 $GOPATH/bin/nancy
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.11/nancy-v1.0.11-linux-amd64" \
+    && chmod 755 /usr/local/bin/nancy
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 


### PR DESCRIPTION
Images for both nancy and node-go dockerfiles updated with latest version of nancy and base template using go1.15.*