### PR TITLE
Upgrade to latest ansible and packer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To build and publish an image:
 ```shell
 # $DIR_NAME in the following is one of the directories in this repo
 cd $DIR_NAME
-docker build -t onsdigital/dp-concourse-tools-$DIR_NAME:latest .
-docker push onsdigital/dp-concourse-tools-$DIR_NAME:latest
+docker build -t onsdigital/dp-concourse-tools-$(basename "${PWD}"):latest .
+docker push onsdigital/dp-concourse-tools-$(basename "${PWD}"):latest
 ```
 
 Contributing

--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,6 +1,16 @@
-FROM williamyeh/ansible:alpine3
+FROM alpine:3
 
-RUN apk add --update bash curl gnupg gzip make git && rm -rf /var/cache/apk/*
+ENV ANSIBLE_VERSION=2.10.6-r0
+ENV PACKER_VERSION=1.7.0
 
-RUN curl https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip | \
+RUN apk add --no-cache \
+        bash \
+        curl \
+        gnupg \
+        gzip \
+        make \
+        git \
+        ansible=$ANSIBLE_VERSION
+
+RUN curl "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" | \
     zcat > /usr/local/bin/packer && chmod +x /usr/local/bin/packer


### PR DESCRIPTION
Upgrade to the latest version of ansible available through the alpine
package manager (2.10.6) and the current latest version of packer.

As part of this change we are switching to installing ansible in our own
image in order to pin the ansible version used.