### PR TITLE
Added 'jq' to the axe image apt installation list

### DIFF
--- a/axe/Dockerfile
+++ b/axe/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.0.1
+FROM node:15.12.0
 
 LABEL maintainer="dev.digitalpublishing@ons.gov.uk"
 

--- a/axe/Dockerfile
+++ b/axe/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="dev.digitalpublishing@ons.gov.uk"
 # Update apt then install wget to set up the Personal Package Archive (PPA) and unzip to install the Chromedriver.
 # Then set up the Chrome PPA and update the package list and install chrome
 RUN apt update \
-    && apt install -y --no-install-recommends wget unzip \
+    && apt install -y --no-install-recommends wget unzip jq \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list \
     && apt update \


### PR DESCRIPTION
### What

jq will be used to better organise the output of the axe tool

### How to review

- Check that jq has been sensibly added to the dockerfile apt installation list
- If you want to run it you can build it with `docker build -t a11y-axe .` then run it with `docker run --name a11y-axe -it /bin/bash` at this point you can use the axe tool e.g. `cd ~; mkdir a11y-reports; A11Y_DIR=a11y-reports; axe --chrome-options="no-sandbox,disable-setuid-sandbox,disable-dev-shm-usage" --dir "$A11Y_DIR" https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/latest`

### Who can review

Anyone except me
