### PR TITLE
Upgrade nancy to latest version (1.0.17)

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.11/nancy-v1.0.11-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.17/nancy-v1.0.17-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 CMD /bin/bash


### PR DESCRIPTION
Upgrade nancy to the latest version (currently 1.0.17).

The main reason for this upgrade is to benefit from the ability to skip the version check that is causing lots of CI failures when all the checks run on Monday morning.