### PR TITLE
Upgrade packer to the latest version

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,7 +1,11 @@
-FROM alpine:3
+# Due to this faccessat2 change: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2
+# we need to continue to use alpine 3.13 until we upgrade to using Docker 20.10.0 or greater, AND libseccomp 2.4.4
+# or greater on concourse workers.
+FROM alpine:3.13
 
-ENV ANSIBLE_VERSION=2.10.6-r0
-ENV PACKER_VERSION=1.7.0
+# IF you update the packer version here you should also rebuild the https://github.com/ONSdigital/packer-resource
+ENV PACKER_VERSION=1.7.8
+ENV ANSIBLE_VERSION=2.10.7-r0
 
 RUN apk add --no-cache \
         bash \
@@ -13,4 +17,4 @@ RUN apk add --no-cache \
         ansible=$ANSIBLE_VERSION
 
 RUN curl "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" | \
-    zcat > /usr/local/bin/packer && chmod +x /usr/local/bin/packer
+        zcat > /usr/local/bin/packer && chmod +x /usr/local/bin/packer


### PR DESCRIPTION
Upgrade packer to the latest version. We need to be careful with the alpine version we use since we are running an older version of docker that will not support versions greater than 3.13.