### PR TITLE
Bump Go and Nancy to latest versions

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.15
+FROM golang:1.17.4
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.17/nancy-v1.0.17-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 CMD /bin/bash

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.15.7
+FROM golang:1.17.4
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.11/nancy-v1.0.11-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 RUN curl -sL https://deb.nodesource.com/setup_13.x | bash


### PR DESCRIPTION
- Bump `go-node` and `nancy` Go version to latest version (1.17.4)
- Update Nancy to latest version (1.0.29)