### PR TITLE
Use buster release

### DIFF
--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.4
+FROM golang:1.17.4-buster
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,3 +1,4 @@
+# Using buster as the default one (bullseye) is not yet supported by nodeJS 13
 FROM golang:1.17.4-buster
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \


### PR DESCRIPTION
The base image seems to have switched to `bullseye` which does not appear to have full support yet and fails to build hence using `buster` now