### PR TITLE
Upgrade base image (golang) to latest version - 1.19.4

### DIFF
--- a/chrome-go/Dockerfile
+++ b/chrome-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.4
+FROM golang:1.19.4
 
 RUN wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list


### PR DESCRIPTION
Bump the base golang image for use by the chrome-go docker image