### PR TITLE
Upgrade nancy and node-go base image of Go to version 1.19.4

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,4 +1,10 @@
-FROM golang:1.17.4
+FROM golang:1.19.4
+
+LABEL go_version=1.19.4
+LABEL nancy_version=1.0.29
+LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
+LABEL folder=nancy
+LABEL git_commit=
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy

--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -4,7 +4,7 @@ LABEL go_version=1.19.4
 LABEL nancy_version=1.0.29
 LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
 LABEL folder=nancy
-LABEL git_commit=
+LABEL git_commit=89424ebec30e26eb2a668d89d533e58e015e1166
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -5,7 +5,7 @@ LABEL go_version="1.19.4"
 LABEL node_version="14"
 LABEL git_repo="https://github.com/ONSdigital/dp-concourse-tools"
 LABEL folder="node-go"
-LABEL git_commit=""
+LABEL git_commit="5ef37cff8df2297d039395bf64f1be600241508c"
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,5 +1,11 @@
-# Using buster as the default one (bullseye) is not yet supported by nodeJS 13
-FROM golang:1.17.4-buster
+FROM golang:1.19.4
+
+# Label docker image
+LABEL go_version="1.19.4"
+LABEL node_version="14"
+LABEL git_repo="https://github.com/ONSdigital/dp-concourse-tools"
+LABEL folder="node-go"
+LABEL git_commit=""
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy


### PR DESCRIPTION
See title, use of labels in dockerfiles so user can run `docker inspect <docker image hash>` to see what file contains (additional information)

Images have been uploaded to dockerhub:

dp-concourse-tools-nancy tags:
1.19.4-rc.1 - Nancy 1.0.29 (latest)
1.17.4-rc.1 - Nancy 1.0.29

dp-concourse-tools-node-go tags:
1.19.4-rc.1 - contains Node version 14 (latest)
1.17.4-rc.2 - contains Node version 14
1.17.4-rc.1 - contains Node version 13
