### PR TITLE
Update docs to include how to version images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What
+
+Describe what you have changed and why.
+
+### How to review
+
+Describe the steps required to test the changes.
+
+### Who can review
+
+Describe who worked on the changes, so that other people can review.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 ONS Digital
+Copyright (c) 2021-2023 ONS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
-Digital Publishing Concourse Tools
-==================================
+## Digital Publishing Concourse Tools
+
 
 Build tools we use in our Concourse CI pipelines as docker images.
 
-Getting started
----------------
+### Getting started
 
-All images are currently published to Docker Hub. You will require a login to the ONSdigital Docker Hub organisation to continue.
+All images are currently published to Docker Hub. You will require a login to the "onsdigital" Docker Hub organisation to continue as well as write permissions to push changes to account.
 
-To build and publish an image:
+On commandline run `docker login` or [see docker docs](https://docs.docker.com/engine/reference/commandline/login/)
+
+If the latest image does not exist as a specific tagged version, you will need to create a new image tagged with correct version. This will allow you to overwrite image tagged latest with new version without losing any images.
+
+1. Rename existing image:
+   1. Find out what version the image for the existing latest version should be.
+      1. It should match the base image version of the dockerfile appended with rc tag, `rc-1` for first image using base image of golang 1.19.3 would result in a tag of `1.19.3-rc.1`. An update to the dockerfile that did not change the base image should move to `1.19.3-rc.2`. An update to the docker file that changed the base image to Go version to 1.19.4 will result in tag to be `1.19.4-rc.1`
+   1. Pull docker image from remote to local docker instance: `docker pull -a onsdigital/dp-concourse-tools-$(basename "${PWD}")`
+   1. Retrieve latest image id: `docker images -a | grep dp-concourse-tools-$(basename "${PWD}")`
+   1. Change tag on existing image: `docker tag <image id retrieved from previous step> onsdigital/dp-concourse-tools-$(basename "${PWD}"):<version, e.g. 1.19.4-rc.1>`
+   1. Push docker changes to remote dockerhub: `docker push onsdigital/dp-concourse-tools-$(basename "${PWD}"):<version>`
+
+Now it is safe to move on to uploading a new latest version of the image, following steps below.
+
+2. To build and publish an image:
 
 ```shell
 # $DIR_NAME in the following is one of the directories in this repo
@@ -16,6 +29,8 @@ cd $DIR_NAME
 docker build -t onsdigital/dp-concourse-tools-$(basename "${PWD}"):latest .
 docker push onsdigital/dp-concourse-tools-$(basename "${PWD}"):latest
 ```
+
+Follow steps in 1. to create a duplicate image tagged with correct semantic version.
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -8,15 +8,23 @@ All images are currently published to Docker Hub. You will require a login to th
 
 On commandline run `docker login` or [see docker docs](https://docs.docker.com/engine/reference/commandline/login/)
 
+### Contents
+
+* [Build and Publish Image](#build-and-publish-image): How to build and publish an image
+* [Tagging Docker Images](#tagging-docker-images): Guidance for tagging docker images
+* [Labelling Dockerfiles](#labelling-docker-images): Guidance for adding labels to dockerfiles
+* [Renaming existing images](#renaming-existing-images): How to rename an existing tagged image
+
 ### Build and Publish Image
 
 #### Prerequisites
 
 - You will need to know what tag you are going to give to your new image, please read the [tagging docker images documentation before continuing](#tagging-docker-images)
 - It is desirable to add Labels to the docker image, please read through the [adding labels documentation before continuing](#labelling-docker-images)
-- Check the current "latest" tagged version of docker repo has an equivalent tag so the image is not lost; if it doesn't exist follow [renaming existing images documentation](#renaming-existing-images)
+- Check the current "latest" tagged version of docker repo has an equivalent tag so the image is not lost
+  - Can use steps 1 to 4 in [renaming existing images documentation](#renaming-existing-images), use step 4 to compare image tag ids for a docker repo to see if latest image tag has a copy
 
-To build and publish an image:
+#### To build and publish an image:
 
 1. Build image under unique tag abiding by [tagging docker instructions](#tagging-docker-images)
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ On commandline run `docker login` or [see docker docs](https://docs.docker.com/e
 
 #### Prerequisites
 
-- You will need to know what tag you are going to give to your new image, please read the [tagging docker images documentation before continuing](#tagging-docker-images)
-- It is desirable to add Labels to the docker image, please read through the [adding labels documentation before continuing](#labelling-docker-images)
+- You will need to know what tag you are going to give to your new image, please read the [tagging docker images](#tagging-docker-images) section before continuing
+- It is desirable to add Labels to the docker image, please read through the [labelling docker images](#labelling-docker-images) section before continuing
 - Check the current "latest" tagged version of docker repo has an equivalent tag so the image is not lost
-  - Can use steps 1 to 4 in [renaming existing images documentation](#renaming-existing-images), use step 4 to compare image tag ids for a docker repo to see if latest image tag has a copy
+  - Can use steps 1 to 4 in [renaming existing images](#renaming-existing-images) section, use step 4 to compare image tag ids for a docker repo to see if latest image tag has a copy
 
 #### To build and publish an image:
 
-1. Build image under unique tag abiding by [tagging docker instructions](#tagging-docker-images)
+1. Build image under unique tag abiding by instructions in [tagging docker images](#tagging-docker-images) section
 
 ```shell
 # $DIR_NAME in the following is one of the directories in this repo
@@ -46,11 +46,11 @@ docker push onsdigital/dp-concourse-tools-$(basename "${PWD}"):latest
 ### Tagging Docker Images
 
 - The base image used in dockerfile should be represented as the first part of the new tag, see table below
-- Other installations in the docker image should also be included
+- Other installations in the docker image should also be added to the tag
 
 | Base Image             | Other installs                 | Tag                                 |
 | ---------------------- | ------------------------------ | ----------------------------------- |
-| FROM maven:3.5.0-jdk-8 | Node 8                         | 3.5.0-node-8                        |
+| FROM maven:3.5.0-jdk-8 | Node 8                         | 3.5.0-jdk-8-node-8                  |
 | FROM golang:1.19.4     | Node 14                        | 1.19.4-node-14                      |
 | FROM golang:1.19.4     | Node 14, golangci-lint v1.51.0 | 1.19.4-node-14-golangci-lint-1.51.0 |
 
@@ -78,7 +78,7 @@ If the latest image does not exist as a specific tagged version, you will need t
 1. Change tag on existing image: `docker tag <image id retrieved from previous step> onsdigital/dp-concourse-tools-$(basename "${PWD}"):<tag>`
 1. Push docker changes to remote dockerhub: `docker push onsdigital/dp-concourse-tools-$(basename "${PWD}"):<tag>`
 
-Now it is safe to move on to uploading a new latest version of the image, [following build and publish image steps](#build-and-publish-image)
+Now it is safe to move on to uploading a new latest version of the image, following [build and publish image](#build-and-publish-image) section.
 
 Contributing
 ------------


### PR DESCRIPTION
### What

Documentation on how we should be versioning our images, previously we relied on always using latest. This becomes less than ideal when our apps are running multiple tasks in ci using different images and these are out of step or worse latest updates and breaks ci tasks which would pass on an older version of an installation in the docker image.

The new documentation is to consolidate a number of things around initial versioning of docker images using the tag naming convention and additional use of labels to assist developers to understand where the image changes are taken place and more importantly when (using git commit hash.

latest tag will always exist as most applications running in ci still rely on this.

### How to review

- Any further suggestions/improvements to how we can version the docker images
- Check guide works

### Who can review

Tech Leads