### PR TITLE
Upgrade Go and Nancy for nancy and node-go

### DIFF
--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -4,7 +4,7 @@ LABEL go_version=1.20.3
 LABEL nancy_version=1.0.42
 LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
 LABEL folder=nancy
-LABEL git_commit=89424ebec30e26eb2a668d89d533e58e015e1166
+LABEL git_commit=39d389d5fc325d37880b20636f3b51c62894479c
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.42/nancy-v1.0.42-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy

--- a/nancy/Dockerfile
+++ b/nancy/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.19.4
+FROM golang:1.20.3
 
-LABEL go_version=1.19.4
-LABEL nancy_version=1.0.29
+LABEL go_version=1.20.3
+LABEL nancy_version=1.0.42
 LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
 LABEL folder=nancy
 LABEL git_commit=89424ebec30e26eb2a668d89d533e58e015e1166
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.42/nancy-v1.0.42-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 CMD /bin/bash

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.19.4
+FROM golang:1.20.3
 
 # Label docker image
-LABEL go_version="1.19.4"
+LABEL go_version="1.20.3"
 LABEL node_version="14"
 LABEL git_repo="https://github.com/ONSdigital/dp-concourse-tools"
 LABEL folder="node-go"
 LABEL git_commit="5ef37cff8df2297d039395bf64f1be600241508c"
 
-RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.29/nancy-v1.0.29-linux-amd64" \
+RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.42/nancy-v1.0.42-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash

--- a/node-go/Dockerfile
+++ b/node-go/Dockerfile
@@ -5,7 +5,7 @@ LABEL go_version="1.20.3"
 LABEL node_version="14"
 LABEL git_repo="https://github.com/ONSdigital/dp-concourse-tools"
 LABEL folder="node-go"
-LABEL git_commit="5ef37cff8df2297d039395bf64f1be600241508c"
+LABEL git_commit="39d389d5fc325d37880b20636f3b51c62894479c"
 
 RUN wget -O /usr/local/bin/nancy "https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.42/nancy-v1.0.42-linux-amd64" \
     && chmod 755 /usr/local/bin/nancy


### PR DESCRIPTION
### What

Bump base image of Go to latest version 1.20.3
Bump Nancy to latest version 1.0.42
