### PR TITLE
Update chrome go dockerfile version to 1.21.5

### DIFF
--- a/chrome-go/Dockerfile
+++ b/chrome-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.4
+FROM golang:1.21.5
 
 RUN wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list


### PR DESCRIPTION
### What

Updated the chrome-go version to 1.21.5 to allow handling of open telemetry instrumentation

### How to review

Check the dockerfile still works as expected

### Who can review

Anyone
