### PR TITLE
feat: add AWS lambda python image

### DIFF
--- a/aws-lambda-python-git/Dockerfile
+++ b/aws-lambda-python-git/Dockerfile
@@ -6,3 +6,4 @@ LABEL git_commit="9f4e35f456bd1680e77b86901dab3e9d8f4509c4"
 LABEL folder="aws-lambda-python-git"
 
 RUN microdnf update && microdnf install git -y  
+RUN pip install poetry


### PR DESCRIPTION
### What

Added Docker image based on the AWS Lambda Python 3.13 image, with added Git.

### How to review

Building the Dockerfile to ensure it's valid, or pulling it from the ECR as I have pushed it for verification.