### PR TITLE
feat: OCI build task image + ECR login

### DIFF
--- a/oci-build-task-ecr/Dockerfile
+++ b/oci-build-task-ecr/Dockerfile
@@ -1,0 +1,15 @@
+FROM concourse/oci-build-task:master AS builder
+
+LABEL oci_build_task_version="master"
+LABEL git_repo="https://github.com/ONSdigital/dp-concourse-tools"
+LABEL git_commit="1757c56a789415bd6a0e25f8176f6fcdfc2be590"
+LABEL folder="oci-build-task-ecr"
+
+RUN apk update && apk add --no-cache aws-cli jq
+
+FROM builder as final
+
+COPY ecr-login-entrypoint.sh /usr/local/bin/ecr-login-entrypoint.sh
+RUN chmod +x /usr/local/bin/ecr-login-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/ecr-login-entrypoint.sh"]

--- a/oci-build-task-ecr/README.md
+++ b/oci-build-task-ecr/README.md
@@ -1,0 +1,37 @@
+# oci-build-task-ecr image
+
+Based off the Concourse CI [oci-build-task](https://github.com/concourse/oci-build-task) image, which is the most recent way of building Docker images in Concourse.
+
+Unlike the older [docker-image-resource](https://github.com/concourse/docker-image-resource/) task, the `oci-build-task` task does not support pushing to OCI image repositories other than `docker.io`.
+
+This image comes with AWS CLI installed + an shell script for an entrypoint to:
+1. Authenticate with a provider ECR registry
+2. Export the credentials for the registry to the Docker config at `~/.docker/config.json`
+3. Execute the normal build task
+
+## Usage
+
+This image should be used the same way as the `oci-build-task` image, so for full examples view either:
+1. [The README in their repository](https://github.com/concourse/oci-build-task)
+2. Their guide for [building and pushing an image](https://concourse-ci.org/building-and-pushing-an-image.html)
+
+For using ECR as a repository, the following params must be set:
+- `ECR_AUTH` should be set to `true`
+- `ECR_REPOSITORY_URI` must match the ECR repository you wish to access
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` must be set to the relevant AWS credentials
+
+You must also set the `path` of `run` in the Concourse CI task to be `/usr/local/bin/ecr-login-entrypoint.sh`
+
+E.g.
+```yaml
+params:
+    CONTEXT: .
+    DOCKERFILE: Dockerfile
+    AWS_ACCESS_KEY_ID: ((aws_access_key_id))
+    AWS_SECRET_ACCESS_KEY: ((aws_secret_access_key))
+    AWS_REGION: ((aws_region))
+    ECR_REPOSITORY_URI: ((aws_ecr_registry_uri))
+    ECR_AUTH: true
+run:
+    path: /usr/local/bin/ecr-login-entrypoint.sh
+```

--- a/oci-build-task-ecr/ecr-login-entrypoint.sh
+++ b/oci-build-task-ecr/ecr-login-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+if [ -z "$AWS_REGION" ]; then
+    echo "AWS_REGION not set"
+    exit 1
+fi
+
+if [ -z "$ECR_REPOSITORY_URI" ]; then
+    echo "ECR_REPOSITORY_URI not set"
+    exit 1
+fi
+
+echo "Starting ECR authentication process..."
+
+if [ "${ECR_AUTH}" = "true" ]; then
+  #Login to ECR -> Create Docker config -> Save
+  echo "ECR authentication enabled, logging in to ${ECR_REPOSITORY_URI}..."
+  
+  mkdir -p ${HOME}/.docker
+    
+  ECR_TOKEN=$(aws ecr get-login-password --region ${AWS_REGION})
+  AUTH_TOKEN=$(echo "AWS:${ECR_TOKEN}" | base64)
+  DOCKER_CONFIG=$(jq -n --arg ecr_registry "$ECR_REPOSITORY_URI" --arg auth_token "$AUTH_TOKEN" '{"auths":{($ecr_registry): {"auth": $auth_token}}}')
+  
+  echo "Generated Docker config"
+
+  echo $DOCKER_CONFIG > $HOME/.docker/config.json  
+
+  echo "Successfully authenticated with ECR"
+else
+  echo "ECR authentication not enabled, skipping..."
+fi
+
+echo "Running build command..."
+exec /usr/bin/build "$@"


### PR DESCRIPTION
### What

Adds Dockerfile for `concourse/oci-build-task`, along with ECR authentication support.

### How to review

Testing the image in a Concourse CI pipeline would be best; instructions for usage are provided in the README. If there are any questions please shout.