### PR TITLE
Upgrade chrome go to 1.24.4

### DIFF
--- a/chrome-go/Dockerfile
+++ b/chrome-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.2-bullseye
+FROM golang:1.24.4-bullseye
 
 RUN wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list


### PR DESCRIPTION
### What

Upgrade chrome-go to 1.24.4

### How to review

- Check looks ok
- Check ECR for deployed image.
- Check PR here: https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-frontend-release-calendar/jobs/pr-component/builds/489 (admittedly the test fails, but it runs and that's the important thing)

### Who can review

Not me. 