### PR TITLE
Add lint-go

### DIFF
--- a/lint-go/Dockerfile
+++ b/lint-go/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24.4-bullseye
+
+ARG GOLANGCILINT_VERSION="2.1.6"
+
+LABEL go_version="1.24.4-bullseye"
+LABEL golangci-lint_version="$GOLANGCILINT_VERSION"
+
+# binary will be $(go env GOPATH)/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v$GOLANGCILINT_VERSION
+
+CMD /bin/bash


### PR DESCRIPTION
### What

Added lint-go image. 

This has been done because golangci-lint don't distribute a `bullseye` variant and pre-installing will speed up runtimes for lint checks. 

### How to review

Check looks ok.

See it in action here: https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-image-api/jobs/pr-lint/builds/16

### Who can review

Not me. 