### PR TITLE
Upgrade chrome-go to 1.24.6

### DIFF
--- a/chrome-go/Dockerfile
+++ b/chrome-go/Dockerfile
@@ -9,9 +9,10 @@ LABEL go_version="$GOLANG_VERSION"
 LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
 LABEL folder="chrome-go"
 
+ARG CHROME_KEY_NAME="/usr/share/keyrings/google-linux-signing-key.gpg"
 
-RUN wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o "$CHROME_KEY_NAME" \
+    && echo "deb [signed-by=$CHROME_KEY_NAME] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
 
 RUN apt-get update && \
     apt-get -y install google-chrome-stable && \

--- a/chrome-go/Dockerfile
+++ b/chrome-go/Dockerfile
@@ -1,4 +1,14 @@
-FROM golang:1.24.5-bullseye
+ARG GOLANG_VERSION="1.24.6-bookworm"
+
+FROM golang:$GOLANG_VERSION
+
+# Has to be redeclared
+ARG GOLANG_VERSION
+
+LABEL go_version="$GOLANG_VERSION"
+LABEL git_repo=https://github.com/ONSdigital/dp-concourse-tools
+LABEL folder="chrome-go"
+
 
 RUN wget -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list

--- a/lint-go/Dockerfile
+++ b/lint-go/Dockerfile
@@ -1,8 +1,12 @@
-FROM golang:1.24.5-bullseye
+ARG GOLANG_VERSION="1.24.6-bookworm"
 
-ARG GOLANGCILINT_VERSION="2.1.6"
+FROM golang:$GOLANG_VERSION
 
-LABEL go_version="1.24.5-bullseye"
+# Has to be redeclared
+ARG GOLANG_VERSION
+ARG GOLANGCILINT_VERSION="2.4.0"
+
+LABEL go_version="${GOLANG_VERSION}"
 LABEL golangci-lint_version="$GOLANGCILINT_VERSION"
 
 # binary will be $(go env GOPATH)/bin/golangci-lint


### PR DESCRIPTION
### What

Upgraded chrome-go and lint-go to 1.24.6

### How to review

Check this PR to see usage and working: https://github.com/ONSdigital/dp-frontend-search-controller/pull/437
Check ECR for images - haven't updated to latest yet, will do so after PR is approved. 

### Who can review

Not me - requires CI access. 