### PR TITLE
New dcind to replace original "taylorsilva/dcind" that does not work on concourse workers built on Ubuntu 22.04

### DIFF
--- a/dcind/Dockerfile
+++ b/dcind/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.22.1
 
 ARG DOCKER_VERSION=
-ARG DOCKER_COMPOSE_VERSION=
 
 # Install Docker and Docker Compose
 RUN apk --no-cache add \

--- a/dcind/Dockerfile
+++ b/dcind/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.22.1
+
+ARG DOCKER_VERSION=
+ARG DOCKER_COMPOSE_VERSION=
+
+# Install Docker and Docker Compose
+RUN apk --no-cache add \
+    bash \
+    curl \
+    util-linux \
+    device-mapper \
+    libffi-dev \
+    openssl-dev \
+    py3-pip \
+    python3-dev \
+    gcc \
+    libc-dev \
+    make \
+    rust \
+    cargo \
+    iptables \
+    docker-cli-compose
+
+RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
+    mv /docker/* /bin/ && \
+    chmod +x /bin/docker* && \
+    printf '#!/bin/sh\nexec docker compose "$@"\n' > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
+    rm -rf /root/.cache
+
+# Include functions to start/stop docker daemon
+COPY docker-lib.sh /docker-lib.sh
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/dcind/Makefile
+++ b/dcind/Makefile
@@ -1,0 +1,25 @@
+SHELL := bash
+
+DOCKER_VERSION = 20.10.24
+DOCKER_COMPOSE_VERSION = 1.29.2
+
+ECR_AWS_ACCOUNT ?= $(shell aws sts get-caller-identity --profile dp-ci --query Account --output text)
+ECR_AWS_ACCOUNT_URL = $(ECR_AWS_ACCOUNT).dkr.ecr.eu-west-2.amazonaws.com
+IMAGE_NAME = ${ECR_AWS_ACCOUNT_URL}/onsdigital/dcind
+
+.PHONY: build
+build:
+	docker build -t ${IMAGE_NAME} \
+		--build-arg DOCKER_VERSION=${DOCKER_VERSION} \
+		--build-arg DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION} \
+		.
+
+.PHONY: publish
+publish:
+	aws ecr get-login-password --region eu-west-2 --profile dp-ci | docker login --username AWS --password-stdin ${ECR_AWS_ACCOUNT_URL}
+
+	docker push ${IMAGE_NAME}
+
+.PHONY: prune
+prune:
+	docker system prune

--- a/dcind/Makefile
+++ b/dcind/Makefile
@@ -1,7 +1,6 @@
 SHELL := bash
 
 DOCKER_VERSION = 20.10.24
-DOCKER_COMPOSE_VERSION = 1.29.2
 
 ECR_AWS_ACCOUNT ?= $(shell aws sts get-caller-identity --profile dp-ci --query Account --output text)
 ECR_AWS_ACCOUNT_URL = $(ECR_AWS_ACCOUNT).dkr.ecr.eu-west-2.amazonaws.com
@@ -11,7 +10,6 @@ IMAGE_NAME = ${ECR_AWS_ACCOUNT_URL}/onsdigital/dcind
 build:
 	docker build -t ${IMAGE_NAME} \
 		--build-arg DOCKER_VERSION=${DOCKER_VERSION} \
-		--build-arg DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION} \
 		.
 
 .PHONY: publish

--- a/dcind/README.md
+++ b/dcind/README.md
@@ -4,6 +4,9 @@ This image is used to run component tests in CI
 
 Files were copied from: https://github.com/taylorsilva/dcind
 
+> [!IMPORTANT]
+> The upstream repo is no longer maintained.
+
 They were then adjusted and updated such that the resulting image works for both:
 
   Ubuntu 22.04 and Ubuntu 20.04

--- a/dcind/README.md
+++ b/dcind/README.md
@@ -13,6 +13,8 @@ They were then adjusted and updated such that the resulting image works for both
 
 to aid updating Concourse VM's from Ubuntu 20.04 to Ubuntu 22.04
 
+The versions of things specified in the files are the latest that can be used for this container to work on both Ubuntu 20.04 and Ubuntu 22.04
+
 ## Build and push to AWS ECR instructions
 
 ### Prerequisites

--- a/dcind/README.md
+++ b/dcind/README.md
@@ -13,7 +13,8 @@ They were then adjusted and updated such that the resulting image works for both
 
 to aid updating Concourse VM's from Ubuntu 20.04 to Ubuntu 22.04
 
-The versions of things specified in the files are the latest that can be used for this container to work on both Ubuntu 20.04 and Ubuntu 22.04
+> [!IMPORTANT]
+> The versions of docker specified in the makefile `20.10.24` is the latest that can be used for this container to work on both Ubuntu 20.04 and Ubuntu 22.04. Do not change until we have migrated to 22.04 for all concourse workers.
 
 ## Build and push to AWS ECR instructions
 

--- a/dcind/README.md
+++ b/dcind/README.md
@@ -1,0 +1,35 @@
+# ONS version of taylorsilva/dcind
+
+This image is used to run component tests in CI
+
+Files were copied from: https://github.com/taylorsilva/dcind
+
+They were then adjusted and updated such that the resulting image works for both:
+
+  Ubuntu 22.04 and Ubuntu 20.04
+
+to aid updating Concourse VM's from Ubuntu 20.04 to Ubuntu 22.04
+
+## Build and push to AWS ECR instructions
+
+### Prerequisites
+
+Log in to the AWS CI account and in "Elastic Container Registry" ensure there is a repository named "onsdigital/dcind".
+
+If it is missing, create it.
+
+### Building and pushing container to AWS ECR
+
+In a terminal, run:
+
+```shell
+make build publish
+```
+
+The `publish` might fail if you are no longer using docker-desktop. A possible fix for this is to remove the following line from `~/.docker/config.json`:
+
+```json
+    "credsStore": "desktop",
+```
+
+And try again.

--- a/dcind/docker-lib.sh
+++ b/dcind/docker-lib.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+DOCKER_DATA_ROOT=${DOCKER_DATA_ROOT:-/scratch/docker}
+
+sanitize_cgroups() {
+  # PATCH: Ubuntu 22.04 (cgroup v2) — skip legacy v1 mounts
+  if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    return 0
+  fi
+
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  echo "Version info:"
+  # --- diagnostics (safe under `set -e`) ---
+  echo "CGMODE: $([ -f /sys/fs/cgroup/cgroup.controllers ] && echo v2 || echo v1)"
+  echo "Kernel: $(uname -srmo)"
+  [ -r /etc/os-release ] && . /etc/os-release && echo "Container OS: ${NAME:-unknown} ${VERSION_ID:-}" || true
+  [ -r /etc/alpine-release ] && echo "Alpine release: $(cat /etc/alpine-release)" || true
+  echo "Planned cgroup driver: $([ -d /run/systemd/system ] && echo systemd || echo cgroupfs)"
+  [ -n "${HOST_OS_VERSION:-}" ] && echo "Host OS (declared): ${HOST_OS_VERSION}"
+
+  echo "Starting Docker..."
+
+  if [ -f /tmp/docker.pid ]; then
+    echo "Docker is already running"
+    return
+  fi
+
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  # PATCH: pick cgroup driver for v1/v2 (only force systemd if systemd exists)
+  if [ -f /sys/fs/cgroup/cgroup.controllers ] && [ -d /run/systemd/system ]; then
+  #  - v2 (Jammy): use systemd
+    server_args="${server_args} --exec-opt native.cgroupdriver=systemd"
+  else
+  #  - v1 (Focal): use cgroupfs
+    server_args="${server_args} --exec-opt native.cgroupdriver=cgroupfs"
+  fi
+
+  export server_args LOG_FILE DOCKER_DATA_ROOT
+  trap stop_docker EXIT
+
+  try_start() {
+    dockerd --data-root $DOCKER_DATA_ROOT ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  if [ "$(command -v declare)" ]; then
+    declare -fx try_start
+
+    if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      return 1
+    fi
+  else
+    try_start
+  fi
+
+  # if Docker is up, print actual driver/version:
+  docker info --format 'CgroupDriver={{.CgroupDriver}} CgroupVersion={{.CgroupVersion}}' 2>/dev/null || true
+  docker version --format 'Server={{.Server.Version}} Client={{.Client.Version}}' 2>/dev/null || docker --version || true
+}
+
+stop_docker() {
+  echo "Stopping Docker..."
+
+  if [ ! -f /tmp/docker.pid ]; then
+    return 0
+  fi
+
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+  rm /tmp/docker.pid
+}

--- a/dcind/docker-lib.sh
+++ b/dcind/docker-lib.sh
@@ -134,10 +134,6 @@ start_docker() {
   else
     try_start
   fi
-
-  # if Docker is up, print actual driver/version:
-  docker info --format 'CgroupDriver={{.CgroupDriver}} CgroupVersion={{.CgroupVersion}}' 2>/dev/null || true
-  docker version --format 'Server={{.Server.Version}} Client={{.Client.Version}}' 2>/dev/null || docker --version || true
 }
 
 stop_docker() {

--- a/dcind/docker-lib.sh
+++ b/dcind/docker-lib.sh
@@ -60,7 +60,7 @@ start_docker() {
   echo "Version info:"
   # --- diagnostics (safe under `set -e`) ---
   echo "CGMODE: $([ -f /sys/fs/cgroup/cgroup.controllers ] && echo v2 || echo v1)"
-  echo "Kernel: $(uname -srmo)"
+  echo "Kernel (container view): $(uname -srmo)"
   [ -r /etc/os-release ] && . /etc/os-release && echo "Container OS: ${NAME:-unknown} ${VERSION_ID:-}" || true
   [ -r /etc/alpine-release ] && echo "Alpine release: $(cat /etc/alpine-release)" || true
   echo "Planned cgroup driver: $([ -d /run/systemd/system ] && echo systemd || echo cgroupfs)"

--- a/dcind/entrypoint.sh
+++ b/dcind/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Based on https://github.com/docker/compose/blob/master/docker-compose-entrypoint.sh
+
+set -e
+
+source /docker-lib.sh
+start_docker
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker-compose "$@"
+fi
+
+# for a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker-compose help "$1" > /dev/null 2>&1; then
+	set -- docker-compose "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
### What

Fix this problem with our dcind container:
22.04 uses cgroup v2 (unified). The dcind script was written for v1, where each controller (cpu, memory, cpuset, …)
 is a separate mount; on v2, there’s just one cgroup2 mount at /sys/fs/cgroup. So the script’s attempt
  to mount -t cgroup -o cpuset … fails, producing the exact error in CI logs. Concourse’s own post about
   running Docker in tasks explicitly calls out that these images “mount all cgroups as read-write,” i.e., they
    rely on that v1 behavior.

### How to review

Compare new code against original, it has the minimal changes (plus some diagnostics output) to get
component tests working on Ubuntu 22.04 and Ubuntu 20.04
Has been tested on weekend where the remaining one concourse worker had been created from ubuntu 22.04
A feature branch specifying this new image was done against dp-cantabular-metadata-exporter, to test.
This link shows the original container failing:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-metadata-exporter/jobs/pr-component/builds/172
This link shows the build of the container created with this PR working:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-metadata-exporter/jobs/pr-component/builds/180

The new diagnostics output shows the later version of Alpine being used:
+ echo 'Container OS: Alpine Linux 3.22.1'
(the original container used: Alpine 3.14.2 as shown in this output before update:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-metadata-exporter/jobs/pr-component/builds/177
)

The last working test build #180 has in its task component log lines:
Kernel: Linux 6.8.0-1035-aws x86_64 Linux

which matches (when logging into the concourse worker built on ubuntu 22.04):
uname -r
6.8.0-1035-aws

-=-
A build on another machine which is still on ubuntu 20.04, thi:
https://concourse.dp-ci.aws.onsdigital.uk/teams/main/pipelines/dp-cantabular-metadata-exporter/jobs/pr-component/builds/182
We see:
+ echo 'Kernel (container view): Linux 5.15.0-1084-aws x86_64 Linux'
indicating the base OS is ubuntu 20.04

And we also see:
Container OS: Alpine Linux 3.22.1
indicating that the new dcind container is being used.

Thus PRS component test completion OK for #180 and #182 show new dcind container works for ubuntu 22.04 and ubuntu 20.04

### Who can review

Platform, or Linden
